### PR TITLE
Fix a StrictMode violation in VideoDecoder#decode.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/VideoDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/VideoDecoder.java
@@ -180,7 +180,11 @@ public class VideoDecoder<T> implements ResourceDecoder<T, Bitmap> {
               outHeight,
               downsampleStrategy);
     } finally {
-      mediaMetadataRetriever.release();
+      if (Build.VERSION.SDK_INT >= VERSION_CODES.Q) {
+        mediaMetadataRetriever.close();
+      } else {
+        mediaMetadataRetriever.release();
+      }
     }
 
     return BitmapResource.obtain(result, bitmapPool);


### PR DESCRIPTION
The explicit termination method MediaMetadataRetriever#close is expected to be called when StrictMode is enabled.

PiperOrigin-RevId: 374525345

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->