### PR TITLE
[ORG] RU-AXAV: Remove some generated accessor methods in TranscoderRegistry.

### DIFF
--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
@@ -399,7 +399,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -408,7 +409,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -476,7 +478,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -490,7 +493,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -519,7 +523,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -531,6 +536,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
@@ -399,7 +399,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -408,7 +409,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -476,7 +478,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -490,7 +493,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -519,7 +523,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -531,6 +536,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
@@ -390,7 +390,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -399,7 +400,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -467,7 +469,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -481,7 +484,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -510,7 +514,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -522,6 +527,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
@@ -390,7 +390,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -399,7 +400,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -467,7 +469,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -481,7 +484,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -510,7 +514,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -522,6 +527,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
@@ -390,7 +390,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -399,7 +400,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -467,7 +469,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -481,7 +484,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -510,7 +514,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -522,6 +527,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
@@ -399,7 +399,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -408,7 +409,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -476,7 +478,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -490,7 +493,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -519,7 +523,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -531,6 +536,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
@@ -399,7 +399,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -408,7 +409,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -476,7 +478,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -490,7 +493,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -519,7 +523,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -531,6 +536,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
@@ -399,7 +399,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
+  public GlideRequest<TranscodeType> transforms(
+      @NonNull Transformation<Bitmap>... transformations) {
     return (GlideRequest<TranscodeType>) super.transforms(transformations);
   }
 
@@ -408,7 +409,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+  public GlideRequest<TranscodeType> optionalTransform(
+      @NonNull Transformation<Bitmap> transformation) {
     return (GlideRequest<TranscodeType>) super.optionalTransform(transformation);
   }
 
@@ -476,7 +478,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+  public GlideRequest<TranscodeType> transition(
+      @NonNull TransitionOptions<?, ? super TranscodeType> options) {
     return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
@@ -490,7 +493,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> addListener(@Nullable RequestListener<TranscodeType> listener) {
+  public GlideRequest<TranscodeType> addListener(
+      @Nullable RequestListener<TranscodeType> listener) {
     return (GlideRequest<TranscodeType>) super.addListener(listener);
   }
 
@@ -519,7 +523,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+  public final GlideRequest<TranscodeType> thumbnail(
+      @Nullable RequestBuilder<TranscodeType>... builders) {
     return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
@@ -531,6 +536,7 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   @Override
+  @Deprecated
   @NonNull
   @CheckResult
   public GlideRequest<TranscodeType> thumbnail(float sizeMultiplier) {

--- a/library/src/main/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistry.java
@@ -81,8 +81,8 @@ public class TranscoderRegistry {
   }
 
   private static final class Entry<Z, R> {
-    private final Class<Z> fromClass;
-    private final Class<R> toClass;
+    @Synthetic final Class<Z> fromClass;
+    @Synthetic final Class<R> toClass;
     @Synthetic final ResourceTranscoder<Z, R> transcoder;
 
     Entry(


### PR DESCRIPTION
Not sure why these started blocking submits now, but...

PiperOrigin-RevId: 396008732

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->